### PR TITLE
Proposal for the IFrame embeding of the icosa Viewer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import { updateUserInfo } from "./states/userinfoslice"
 import { library } from "@fortawesome/fontawesome-svg-core"
 import { fab } from "@fortawesome/free-brands-svg-icons"
 import { fas } from "@fortawesome/free-solid-svg-icons"
+import SketchViewEmbed from "./pages/sketch/embed"
 
 library.add(fab, fas)
 
@@ -56,28 +57,33 @@ class App extends React.Component {
       <div className="App">
         <RecoilRoot>
           <Router>
-            <SideNav collapsed={this.state.navCollapsed} toggleNav={this.toggleNav} />
-            <main
-              onClick={(e) => {
-                if (!this.state.navCollapsed) {
-                  this.closeNav()
-                  e.preventDefault()
-                  return
-                }
-              }}
-            >
-              <Header toggleNav={this.openNav} />
-              <Switch>
-                {Routes.map((route, key) => {
-                  let children = route.component
-                  if (route.requiresLogin && !this.props.user) {
-                    children = <Redirect to="/login" />
-                  }
-                  return <Route key={key} path={route.path} exact={route.exact} children={children}></Route>
-                })}
-              </Switch>
-              <Footer />
-            </main>
+            <Switch>
+              <Route exact path="/embed/:userid/:id" children={SketchViewEmbed} />
+              <Route path="/">
+                <SideNav collapsed={this.state.navCollapsed} toggleNav={this.toggleNav} />
+                <main
+                  onClick={(e) => {
+                    if (!this.state.navCollapsed) {
+                      this.closeNav()
+                      e.preventDefault()
+                      return
+                    }
+                  }}
+                >
+                  <Header toggleNav={this.openNav} />
+                  <Switch>
+                    {Routes.map((route, key) => {
+                      let children = route.component
+                      if (route.requiresLogin && !this.props.user) {
+                        children = <Redirect to="/login" />
+                      }
+                      return <Route key={key} path={route.path} exact={route.exact} children={children}></Route>
+                    })}
+                  </Switch>
+                  <Footer />
+                </main>
+              </Route>
+            </Switch>
           </Router>
         </RecoilRoot>
       </div>

--- a/src/pages/sketch/embed/index.js
+++ b/src/pages/sketch/embed/index.js
@@ -1,0 +1,3 @@
+import SketchViewEmbed from "./sketchviewembed"
+
+export default SketchViewEmbed

--- a/src/pages/sketch/embed/sketchviewembed.js
+++ b/src/pages/sketch/embed/sketchviewembed.js
@@ -1,0 +1,31 @@
+import React from "react"
+import { withRouter } from "react-router"
+import SketchViewer from "../../../components/sketch/sketch-viewer"
+import "./sketchview.scss"
+import Loader from "../../../components/ui/loader"
+import AssetsAPI from "../../../api/assets"
+
+class SketchViewEmbed extends React.Component {
+  constructor(props) {
+    const { id, userid } = props.match.params
+    super(props)
+    this.state = { loading: true, id, userid }
+    this.getAsset()
+  }
+
+  getAsset = async () => {
+    const asset = await AssetsAPI.getAsset(this.state.userid, this.state.id)
+    this.setState({ asset: asset, loading: false })
+  }
+
+  render() {
+    if (this.state.loading) {
+      return <Loader />
+    }
+    return (
+      <SketchViewer asset={this.state.asset} />
+    )
+  }
+}
+
+export default withRouter(SketchViewEmbed)


### PR DESCRIPTION
This is a base proposal, I could not yet test it, so it is not ready to be merged just yet (see https://github.com/icosa-gallery/icosa-viewer/issues/13) 

The logic is to use the Nested Route from react-router, to avoid rendering the menus, headers, etc, and skipping to only rendering the App base HTML + the viewer. 

Feel free to comment, I'm happy to work on this feature!